### PR TITLE
Allow empty entries in the configuration file

### DIFF
--- a/KleeRunner/Runners/RunnerBase.py
+++ b/KleeRunner/Runners/RunnerBase.py
@@ -73,7 +73,7 @@ class RunnerBaseClass(metaclass=abc.ABCMeta):
 
   def _setupAdditionalArgs(self, rc):
     self.additionalArgs = [ ]
-    if 'additional_args' in rc:
+    if 'additional_args' in rc and rc['additional_args'] is not None:
       if not isinstance(rc['additional_args'],list):
         raise RunnerBaseException('"additional_args" should be a list')
 
@@ -86,7 +86,7 @@ class RunnerBaseClass(metaclass=abc.ABCMeta):
   def _setupEnvironmentVariables(self, rc):
     # Set environment variables
     self.toolEnvironmentVariables = {}
-    if 'env' in rc:
+    if 'env' in rc and rc['env'] is not None:
       if not isinstance(rc['env'],dict):
         raise RunnerBaseException('"env" must map to a dictionary')
 


### PR DESCRIPTION
Removing line 19 (`LD_LIBRARY_PATH: "..."`) from [the example klee_psutil.yml](https://github.com/delcypher/klee-runner/blob/master/example_configs/klee_psutil.yml) causes the runner to fail, as the entry `venv` is now `None` and therefore not a dictionary anymore.